### PR TITLE
#128: being able to interact with pdb through the docker terminal

### DIFF
--- a/backend/dps_training_k/docker-compose.yml
+++ b/backend/dps_training_k/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     expose:
       - 8000
     command: uvicorn configuration.asgi:application --host 0.0.0.0 --reload
+    stdin_open: true
+    tty: true
 
 
   postgres:


### PR DESCRIPTION
We can use pdb - a command line debugger for python similar to gdb for c.
For that just write `breakpoint()` anywhere.
If this line is executed the pdb cli starts and u can interact with it in either the docker terminal directly or attach yourself to it via `docker attach K-dPS-django`

Using a full proper debugger with GUI in e.g. PyCharm seems to be a bigger undertaking as we would probably need a whole new second debugging setup where nginx and co have to communicate with an outside django etc.
You can try that too, but I think the ROI would be too small for me and my pace at configuring this